### PR TITLE
Forces screenreader focus on the result count outside of tab index

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -71,8 +71,8 @@
 	</div>
 </div>
 <div>
-	<p role="alert" *ngIf="filteredDataLength <= 0">No results available for the selected criteria.  Please adjust the filter options above.</p>
-	<p role="alert" *ngIf="filteredDataLength > 0 && filteredDataLength < dataHouse.items.length">Found {{filteredDataLength}} items out of {{dataHouse.items.length}} total items.</p>
+	<p role="alert" id="noResult" tabindex="-1" *ngIf="filteredDataLength <= 0">No results available for the selected criteria.  Please adjust the filter options above.</p>
+	<p role="alert" id="resultCount" tabindex="-1" *ngIf="filteredDataLength > 0 && filteredDataLength < dataHouse.items.length"><span class="sr-only">Search results </span>Found {{filteredDataLength}} items out of {{dataHouse.items.length}} total items.</p>
 </div>
 <div>
 	<div *ngIf="!imagePosition || 'left' === imagePosition || 'right' === imagePosition">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -313,6 +313,7 @@ export class AppComponent {
         this.filteredData = new FilterPipe(this.globalsService).transform(this.dataHouse.items,
             mockFormVals, this.searchFields, this.dataHouse.sorts, this.filterIncludeSubs);
         this.filteredDataLength = this.filteredData.length;
+        (this.filteredDataLength > 0) ? document.getElementById('resultCount').focus() : document.getElementById('noResult').focus(); //force screen reader to focus on element
         this.setupCurrentPage();
 
         this.updatePathForFilters( '?' + filterField + '=' + filterValue );
@@ -368,6 +369,7 @@ export class AppComponent {
         const end = +this.currentPage * +this.itemsPerPage;
         const start = +end - +this.itemsPerPage;
         this.currentPageData = this.filteredData.slice(start, end);
+
     }
 
     setDefaultFilters( defaultFilterParam: string ) {


### PR DESCRIPTION
First attempt to force-read results on load.