### PR TITLE
Formatted queryString to accept '+' in the search params

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -538,7 +538,7 @@ export class AppComponent {
             function($0, $1, $2, $3) {
                 const qsKey = decodeURIComponent( $1 );
                 const qsVal = decodeURIComponent( $3 );
-                queryString[qsKey] = qsVal;
+                queryString[qsKey] = qsVal.replace(/\+/g,' ');
                 return '';
             }
         );


### PR DESCRIPTION
An issue arose where a user would click from the intranet to a filter and it would have window.location.search params to be separated by "+" instead of the expected %20. getAllQueryStringParams() would take whatever was handed to it and think that is what the search values were. Now, the value before the object from the function is returned, it checks for and removes "+" via regex.