### PR TITLE
Updated filters and sorts to work on keypress and click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6117,6 +6117,11 @@
       "integrity": "sha1-43zwsX8ZnM4jvqcbIDk5Uka07E4=",
       "dev": true
     },
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+    },
     "js-base64": {
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.8.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@angular/router": "6.1.3",
     "@ng-bootstrap/ng-bootstrap": "^3.1.0",
     "core-js": "^2.4.1",
+    "jquery": "^3.3.1",
     "less": "^2.7.3",
     "ngx-pagination": "^3.1.1",
     "rxjs": "^6.2.2",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -21,7 +21,7 @@
                             {{filterText(filter)}}
                         </button>
                         <div class="dropdown-menu" [attr.aria-labelledby]="'button-'+filter">
-                            <a href="#" [attr.class]="'dropdown-item '+vals.class" *ngFor="let vals of dataHouse.filters[filter]" (click)="changeFilter(filter,vals.raw)">{{vals.title}}</a>
+                            <a href="#" [attr.class]="'dropdown-item '+vals.class" *ngFor="let vals of dataHouse.filters[filter]" (click)="this.filterModel[filter] = vals.raw;">{{vals.title}}</a>
                         </div>
                     </div>
                     <input type="hidden" name="filter-{{filter}}" class="form-control" [(ngModel)]="filterModel[filter]" (change)="!submitButton ? updateFilter(filtersubmit.value): ''">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,6 +5,7 @@ import {GlobalsService} from './globals.service';
 import {Location, LocationStrategy, PathLocationStrategy, APP_BASE_HREF, DatePipe} from '@angular/common';
 import { AttrAst } from '@angular/compiler';
 import { NgForm } from '@angular/forms';
+import * as $ from 'jquery';
 
 @Component({
     selector: 'sort-filter-root',
@@ -318,10 +319,16 @@ export class AppComponent {
             // remove spinner
             loadingElement.parentNode.removeChild(loadingElement);
         });
-        if(!this.submitButton){
-            this.delaySearch("keyup", 2000);
-        }
+
+        window.addEventListener('click', (event)=>{
+            if($(event.target).parent().hasClass('dropdown-menu') && !this.submitButton){
+                this.updateFilter(this.filtersubmit.value);
+            }
+        });
         window.addEventListener("keyup", (e) =>{
+            if(!this.submitButton){
+                this.delaySearch("keyup", 2000);
+            }
             if(e.keyCode === 13){
                 this.updateFilter(this.filtersubmit.value);
             };
@@ -428,18 +435,6 @@ export class AppComponent {
 
         // Initial pagination
         this.setupCurrentPage();
-    }
-
-    changeFilter(filter: string, value: string){
-        this.filterModel[filter] = value;
-        if(!this.submitButton){
-            this.delaySearch("click", 2000);
-        window.addEventListener("keyup", (e)=>{     
-                if(e.keyCode === 13){
-                    this.updateFilter(this.filtersubmit.value);
-                };
-            });
-        }
     }
 
     delaySearch(eventType: string, delay: number){


### PR DESCRIPTION
Jeff reported that the filter would not sort on sort click, but would on a return keypress. I added an event listener to listen for click events and modified the keyup event a smidge. Now that we're using jquery, I will need to rework the event listeners to listen to the object clicked instead of the whole window.