### PR TITLE
Filter no longer searching multiple times on submit

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -24,7 +24,7 @@
                             <a href="#" [attr.class]="'dropdown-item '+vals.class" *ngFor="let vals of dataHouse.filters[filter]" (click)="this.filterModel[filter] = vals.raw;">{{vals.title}}</a>
                         </div>
                     </div>
-                    <input type="hidden" name="filter-{{filter}}" class="form-control" [(ngModel)]="filterModel[filter]" (change)="!submitButton ? updateFilter(filtersubmit.value): ''">
+                    <input type="hidden" name="filter-{{filter}}" class="form-control" [(ngModel)]="filterModel[filter]">
 				</div>
 				<div *ngIf="0 === filterFields.length % 2" class="col-md-6 mb-3 order-1 order-md-2">
                     <label *ngIf="sortOptions && sortOptions.length" for="Sort" class="forms-label h5 open">Sort</label>
@@ -36,7 +36,7 @@
                             <a class="dropdown-item" href="#" *ngFor="let sortOption of sortOptions" (click)="updateSorts(sortOption.value,sortOption.label)">{{sortOption.label}}</a>
                         </div>
                     </div>
-                    <input type="hidden" name="Sort" class="form-control" [(ngModel)]="sortValue" (change)="!submitButton ? updateFilter(filtersubmit.value): ''">
+                    <input type="hidden" name="Sort" class="form-control" [(ngModel)]="sortValue">
 				</div>
 			</div>
 			<div class="row">
@@ -55,7 +55,7 @@
                             <a class="dropdown-item" href="#" *ngFor="let sortOption of sortOptions" (click)="updateSorts(sortOption.value,sortOption.label)">{{sortOption.label}}</a>
                         </div>
                     </div>
-                    <input type="hidden" name="Sort" class="form-control" [(ngModel)]="sortValue" (change)="!submitButton ? updateFilter(filtersubmit.value): ''">
+                    <input type="hidden" name="Sort" class="form-control" [(ngModel)]="sortValue">
 				</div>
 			</div>
 		</form>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -326,10 +326,10 @@ export class AppComponent {
             }
         });
         window.addEventListener("keyup", (e) =>{
-            if(!this.submitButton){
+            if(!this.submitButton && $(e.target).attr('id') === 'Search'){
                 this.delaySearch("keyup", 2000);
             }
-            if(e.keyCode === 13){
+            if(e.keyCode === 13 && !$(e.target).parent().hasClass('dropdown-menu')){
                 this.updateFilter(this.filtersubmit.value);
             };
         });
@@ -441,7 +441,6 @@ export class AppComponent {
         const app = this;
         let interval: any;
         window.addEventListener(eventType, (e) =>{
-            //If no submit button, check for changes and update
             clearInterval(interval);
             let functionTimer: any;
             
@@ -450,8 +449,8 @@ export class AppComponent {
                 if((functionTimer - app.timer) > 1000){
                     app.updateFilter(app.filtersubmit.value);   
                     app.timer = Date.now();
-                    clearInterval(interval);
-                }
+                };
+                clearInterval(interval);
             }, delay);
         });
     }


### PR DESCRIPTION
Delaysearch() wasn't clearing the interval at the right place and the search would actually execute multiple times. Multiple calls from filters and sort were being made on functions that are being captured on window events and I favored the window events over the local calls to reduce the number of event listeners.

The only reason this was ever a noticeable issue was due to the fact that every time the search would execute, the page would automatically scroll to the top after the search was executed. This only occured in scenarios where there was no submit button present and the options were tabbed through. A review of this code may be necessary as the dropdown functions are going to undergo a change where enter/return no longer executes the forms that contain the dropdowns.