### PR TITLE
Fixes WCMSRD-7337 and adds keybindings

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -18,10 +18,10 @@
                     <label for="filter-{{filter}}" class="forms-label h5 open">Filter by {{filter}}</label>
                     <div class="dropdown" id="filter-{{filter}}">
                         <button class="btn dropdown-toggle form-control text-left td-none" id="button-{{filter.toLowerCase().replace(' ','-')}}" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            {{filterText(filter)}}
+                            Select {{filter}}
                         </button>
                         <div class="dropdown-menu" [attr.aria-labelledby]="'button-'+filter">
-                            <a href="#" [attr.class]="(!filterModel[filter] || filterModel[filter] == null) ? 'dropdown-item selected' : 'dropdown-item'" (click)="filterModel[filter] = null;" (keyup)="selectFilter($event, filter, null)">Select {{filter}}</a>
+                            <a href="#" [attr.class]="(filterModel[filter] == '') ? 'dropdown-item selected' : 'dropdown-item'" (click)="filterModel[filter] = '';" (keyup)="selectFilter($event, filter, [])">Select {{filter}}</a>
                             <a href="#" [attr.class]="(filterModel[filter] == vals.raw) ? 'dropdown-item selected ' + vals.class : 'dropdown-item '+ vals.class" *ngFor="let vals of dataHouse.filters[filter]" (click)="filterModel[filter] = vals.raw;" (keyup)="selectFilter($event, filter, vals)">{{vals.title}}</a>
                         </div>
                     </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -17,11 +17,12 @@
 				<div *ngFor="let filter of filterFields" class="col-md-6 mb-3">
                     <label for="filter-{{filter}}" class="forms-label h5 open">Filter by {{filter}}</label>
                     <div class="dropdown" id="filter-{{filter}}">
-                        <button class="btn dropdown-toggle form-control text-left td-none" id="button-{{filter}}" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <button class="btn dropdown-toggle form-control text-left td-none" id="button-{{filter.toLowerCase().replace(' ','-')}}" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             {{filterText(filter)}}
                         </button>
                         <div class="dropdown-menu" [attr.aria-labelledby]="'button-'+filter">
-                            <a href="#" [attr.class]="'dropdown-item '+vals.class" *ngFor="let vals of dataHouse.filters[filter]" (click)="this.filterModel[filter] = vals.raw;">{{vals.title}}</a>
+                            <a href="#" [attr.class]="(!filterModel[filter] || filterModel[filter] == null) ? 'dropdown-item selected' : 'dropdown-item'" (click)="filterModel[filter] = null;" (keyup)="selectFilter($event, filter, null)">Select {{filter}}</a>
+                            <a href="#" [attr.class]="(filterModel[filter] == vals.raw) ? 'dropdown-item selected ' + vals.class : 'dropdown-item '+ vals.class" *ngFor="let vals of dataHouse.filters[filter]" (click)="filterModel[filter] = vals.raw;" (keyup)="selectFilter($event, filter, vals)">{{vals.title}}</a>
                         </div>
                     </div>
                     <input type="hidden" name="filter-{{filter}}" class="form-control" [(ngModel)]="filterModel[filter]">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -323,7 +323,6 @@ export class AppComponent {
     ngAfterViewInit(){
         if(!this.submitButton){
             $('#Search').on('keyup', ()=>{
-                console.log('test');
                 this.delaySearch("keyup", 2000);
             });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -323,6 +323,7 @@ export class AppComponent {
     ngAfterViewInit(){
         if(!this.submitButton){
             $('#Search').on('keyup', ()=>{
+                console.log('test');
                 this.delaySearch("keyup", 2000);
             });
 
@@ -510,7 +511,9 @@ export class AppComponent {
             }
         }
         this.updatePathForFilters( qs );
-        this.searchFocus();
+        if(!$('.dropdown-menu').hasClass('show')){
+            this.searchFocus();
+        }
     }
 
     updateSorts(sortValue: any, sortLabel: any){

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,9 +1,8 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, AfterViewInit} from '@angular/core';
 import {MediadataService} from './mediadata.service';
 import {FilterPipe} from './filter.pipe';
 import {GlobalsService} from './globals.service';
 import {Location, LocationStrategy, PathLocationStrategy, APP_BASE_HREF, DatePipe} from '@angular/common';
-import { AttrAst } from '@angular/compiler';
 import { NgForm } from '@angular/forms';
 import * as $ from 'jquery';
 
@@ -317,22 +316,36 @@ export class AppComponent {
             });
 
             // remove spinner
-            loadingElement.parentNode.removeChild(loadingElement);
+            loadingElement.parentNode.removeChild(loadingElement);  
         });
+    }
 
-        window.addEventListener('click', (event)=>{
-            if($(event.target).parent().hasClass('dropdown-menu') && !this.submitButton){
-                this.updateFilter(this.filtersubmit.value);
-            }
-        });
-        window.addEventListener("keyup", (e) =>{
-            if(!this.submitButton && $(e.target).attr('id') === 'Search'){
+    ngAfterViewInit(){
+        if(!this.submitButton){
+            $('#Search').on('keyup', ()=>{
                 this.delaySearch("keyup", 2000);
-            }
-            if(e.keyCode === 13 && !$(e.target).parent().hasClass('dropdown-menu')){
-                this.updateFilter(this.filtersubmit.value);
+            });
+
+            window.onclick = (e)=>{
+                //window click events capture both keypress and click as click
+                if($(e.target).parent().hasClass('dropdown-menu')){
+                    this.updateFilter(this.filtersubmit.value);
+                }
             };
-        });
+        }
+    }
+
+    selectFilter(e: KeyboardEvent, filter: string, value:any){
+        if(e.keyCode === 40 || e.keyCode === 38 || e.keyCode == 9){ //Arrow Down/Up & Tab
+            const filterString = filter.toLowerCase().replace(" ", '-');
+            if(value){
+                this.filterModel[filter] = value.raw;
+                $('#button-'+filterString).html(value.title);
+            } else {
+                this.filterModel[filter] = null;
+                $('#button-'+filterString).html("Select "+filter);
+            }
+        }
     }
 
     getCommentAnchor() {
@@ -387,7 +400,7 @@ export class AppComponent {
                 if(keys[i] === filter){
                     for(let j=0; j<values.length; j++){
                         if(values[j].raw == this.filterModel[filter]){
-                            return values[j].title;
+                            returnValue = values[j].title;
                         } 
                     }  
                 }
@@ -418,8 +431,9 @@ export class AppComponent {
         this.searched = false;
         for ( const property in this.filterModel ) {
             if ( this.filterModel.hasOwnProperty( property ) ) {
-                this.filterModel[property] = '';
-                document.getElementById('button-'+property).innerHTML = "Select "+property;
+                this.filterModel[property] = null;
+                //syntax changed for proper IDs in DOM
+                document.getElementById('button-'+property.toLowerCase().replace(" ",'-')).innerHTML = "Select "+property;
             }
         }
 


### PR DESCRIPTION
So, according to how we do things, Enter must still be the means by which we submit the form when there is no submit button present. However, I've bound the tab and arrow keys to select between the different options and reflect in the button text. You can press escape to get out of the menu. Unfortunately, I couldn't override Bootstrap's tabbing behavior, so I had to find a way around it. Bootstrap has their own events for this and I don't know what they are at this time. I know for the dropdowns themselves, there are several events, such as "shown.bs.dropdown".