### PR TITLE
Refixes jumping to top

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -703,7 +703,9 @@ export class AppComponent {
     changeCurrentPage( pageNumber: number ): void {
         this.currentPage = pageNumber;
         const queryArr = this.getAllQueryStringParams();
-        queryArr['Page'] = pageNumber;
+        if(pageNumber != 1){
+            queryArr['Page'] = pageNumber;
+        }
         let qs = '';
         for ( const key in queryArr ) {
             if(queryArr[key]){
@@ -718,7 +720,9 @@ export class AppComponent {
         }
         this.updatePathForFilters( qs );
         const scrollTop = $('#sort-filter-desc').offset().top;
-        window.scroll(0,scrollTop);
+        if(queryArr['Page']){
+            window.scroll(0,scrollTop);
+        }
         this.setupCurrentPage();
     }
 


### PR DESCRIPTION
Heather discovered an issue during regression testing where the page would jump on calls other than pagination. This fixes the issue by verifying that the page number is something other than 1. At which case, it will execute window.scroll().