### PR TITLE
Removed limit on filters in card

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -135,7 +135,7 @@
 								</ng-container>
 								<ng-container *ngIf="displayFilterVals">
 									<p *ngFor="let filter of filterFields"><span *ngIf="!isLabelHidden(filter)" [innerHtml]="filter+': '"></span>
-										<ng-container *ngFor="let filterVal of item[filter] | slice:0:10; let last = last">
+										<ng-container *ngFor="let filterVal of item[filter]; let last = last">
 											<a href="" (click)="doFilter(filter, filterVal)" [innerHtml]="formatForView(filterVal)"></a><ng-container *ngIf="!last">, </ng-container>
 										</ng-container>
 									</p>
@@ -216,7 +216,7 @@
 								</ng-container>
 								<ng-container *ngIf="displayFilterVals">
 									<p *ngFor="let filter of filterFields"> <span *ngIf="!isLabelHidden(filter)" [innerHtml]="filter+': '"></span>
-										<ng-container *ngFor="let filterVal of item[filter] | slice:0:10; let last = last">
+										<ng-container *ngFor="let filterVal of item[filter]; let last = last">
 											<a href="" (click)="doFilter(filter, filterVal)" [innerHtml]="formatForView(filterVal)"></a><ng-container *ngIf="!last">, </ng-container>
 										</ng-container>
 									</p>


### PR DESCRIPTION
It appears that the slice 0:10 was intended to limit the number of filters a result could have. I think this may have been a styling decision, but now it seems to be unnecessary.